### PR TITLE
Add openreview link and update steam link format

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ author:
   xing             :
   youtube          :
   wikipedia        :
+  openreview       : # e.g., "openreview username"
 
 
 # Reading Files

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -83,7 +83,7 @@
         <li><a href="https://foursquare.com/{{ author.foursquare }}"><i class="fab fa-fw fa-foursquare" aria-hidden="true"></i> Foursquare</a></li>
       {% endif %}
       {% if author.steam %}
-        <li><a href="https://steamcommunity.com/id/{{ author.steam }}"><i class="fab fa-fw fa-steam-square" aria-hidden="true"></i> Steam</a></li>
+        <li><a href="https://steamcommunity.com/profiles/{{ author.steam }}"><i class="fab fa-fw fa-steam-square" aria-hidden="true"></i> Steam</a></li>
       {% endif %}
       {% if author.youtube %}
         <li><a href="https://www.youtube.com/user/{{ author.youtube }}"><i class="fab fa-fw fa-youtube" aria-hidden="true"></i> YouTube</a></li>
@@ -105,6 +105,9 @@
       {% endif %}
       {% if author.googlescholar %}
         <li><a href="{{ author.googlescholar }}"><i class="fas fa-fw fa-graduation-cap"></i> Google Scholar</a></li>
+      {% endif %}
+      {% if author.openreview %}
+        <li><a href="https://openreview.net/profile?id={{ author.openreview }}"><i class="fas fa-fw fa-book" aria-hidden="true"></i> Openreview</a></li>
       {% endif %}
       {% if author.pubmed %}
         <li><a href="{{ author.pubmed }}"><i class="ai ai-pubmed-square ai-fw"></i> PubMed</a></li>
@@ -178,7 +181,7 @@
         <a href="https://foursquare.com/{{ author.foursquare }}"><i class="fab fa-fw fa-foursquare" aria-hidden="true"></i></a>
       {% endif %}
       {% if author.steam %}
-        <a href="https://steamcommunity.com/id/{{ author.steam }}"><i class="fab fa-fw fa-steam-square" aria-hidden="true"></i></a>
+        <a href="https://steamcommunity.com/profiles/{{ author.steam }}"><i class="fab fa-fw fa-steam-square" aria-hidden="true"></i></a>
       {% endif %}
       {% if author.youtube %}
         <a href="https://www.youtube.com/user/{{ author.youtube }}"><i class="fab fa-fw fa-youtube" aria-hidden="true"></i></a>
@@ -200,6 +203,9 @@
       {% endif %}
       {% if author.googlescholar %}
         <a href="{{ author.googlescholar }}"><i class="fas fa-fw fa-graduation-cap"></i></a>
+      {% endif %}
+      {% if author.openreview %}
+        <a href="https://openreview.net/profile?id={{ author.openreview }}"><i class="fa fa-book" aria-hidden="true"></i></a>
       {% endif %}
       {% if author.pubmed %}
         <a href="{{ author.pubmed }}"><i class="ai ai-pubmed-square ai-fw"></i></a>


### PR DESCRIPTION
@RayeRen Hi~
Steam has changed its user link to `https://steamcommunity.com/profiles/{{ author.steam }}`, and the old link `https://steamcommunity.com/id/{{ author.steam }}`  can not be opened correctly. So I changed the steam link format in **_includes/author-profile.html**.

I have also add a link for **openreview** in **author-profile** as well as **_config.yml**, since `openreview.net` has been widely used for paper reviewing, especially for computer science domain.